### PR TITLE
Change `cp`/`chmod` to `install` in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@ clean:
 	rm -f *.o *.gch dwmblocks
 install: output
 	mkdir -p $(DESTDIR)$(PREFIX)/bin
-	cp -f dwmblocks $(DESTDIR)$(PREFIX)/bin
-	chmod 755 $(DESTDIR)$(PREFIX)/bin/dwmblocks
+	install -m 0755 dwmblocks $(DESTDIR)$(PREFIX)/bin/dwmblocks
 uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/bin/dwmblocks


### PR DESCRIPTION
The install command was meant for exactly this purpose; installing a file to a location and setting its permissions. This combines the `cp` and `chmod` commands into one `install` command.