### PR TITLE
New feature: blocks admit a post string in configuration file

### DIFF
--- a/blocks.h
+++ b/blocks.h
@@ -1,19 +1,19 @@
 //Modify this file to change what commands output to your statusbar, and recompile using the make command.
 static const Block blocks[] = {
-	/*Icon*/	/*Command*/		/*Update Interval*/	/*Update Signal*/
-	{"", "cat ~/.pacupdate | sed /📦0/d",					0,		9},
+	/*Icon*/	/*Command*/	/*Post String*/	/*Update Interval*/	/*Update Signal*/
+	{"", "cat ~/.pacupdate | sed /📦0/d", "", 0, 9},
 	
-	{"🧠", "free -h | awk '/^Mem/ { print $3\"/\"$2 }' | sed s/i//g",	30,		0},
+	{"🧠", "free -h | awk '/^Mem/ { print $3\"/\"$2 }' | sed s/i//g", "", 30, 0},
 
-	{"", "~/bin/statusbar/volume",						0,		10},
+	{"", "~/bin/statusbar/volume", "", 0, 10},
 
-	{"☀", "xbacklight | sed 's/\\..*//'",					0,		11},
+	{"☀", "xbacklight | sed 's/\\..*//'", "", 0, 11},
 	
-	{"", "~/bin/statusbar/battery",						5,		0},
+	{"", "~/bin/statusbar/battery", "", 5, 0},
 
-	{"🌡", "sensors | awk '/^temp1:/{print $2}'",				5,		0},
+	{"🌡", "sensors | awk '/^temp1:/{print $2}'", "", 5, 0},
 
-	{"", "~/bin/statusbar/clock",						5,		0},
+	{"", "~/bin/statusbar/clock", "", 5, 0},
 };
 
 //sets delimeter between status commands. NULL character ('\0') means no delimeter.

--- a/dwmblocks.c
+++ b/dwmblocks.c
@@ -10,6 +10,7 @@
 typedef struct {
 	char* icon;
 	char* command;
+	char* poststr;
 	unsigned int interval;
 	unsigned int signal;
 } Block;
@@ -48,8 +49,13 @@ void getcmd(const Block *block, char *output)
 	int i = strlen(block->icon);
 	fgets(output+i, CMDLENGTH-i, cmdf);
 	i = strlen(output);
-	if (delim != '\0' && --i)
-		output[i++] = delim;
+	if (--i)
+	{
+	    strcpy(output+i, block->poststr);
+	    i = strlen(output);
+	    if (delim != '\0')
+		    output[i++] = delim;
+	}
 	output[i++] = '\0';
 	pclose(cmdf);
 }


### PR DESCRIPTION
In the same way one can specify an icon (or string) before the block, this feature introduces the possibility of specifying a string after the block.

This pull request is related to issue #13: One can now introduces characters before and after the block simulating a sort of multistring separator.

This feature allows to cleanly separate the output block script from the statusbar configuration, making it possible to recycle scripts used for other status bars