### PR TITLE
Fixes #9 - determine the size of the status buffer based on the number of blocks

### DIFF
--- a/dwmblocks.c
+++ b/dwmblocks.c
@@ -6,6 +6,7 @@
 #include<X11/Xlib.h>
 #define LENGTH(X)               (sizeof(X) / sizeof (X[0]))
 #define CMDLENGTH		50
+#define STATUSLENGTH (LENGTH(blocks) * CMDLENGTH + 1)
 
 typedef struct {
 	char* icon;
@@ -32,7 +33,7 @@ static Display *dpy;
 static int screen;
 static Window root;
 static char statusbar[LENGTH(blocks)][CMDLENGTH] = {0};
-static char statusstr[2][256];
+static char statusstr[2][STATUSLENGTH];
 static int statusContinue = 1;
 static void (*writestatus) () = setroot;
 


### PR DESCRIPTION
prevents dwmblocks from crashing because of the status string getting longer than the underlying buffer