### PR TITLE
Fix blocks width getting messed up

### DIFF
--- a/dwmblocks.c
+++ b/dwmblocks.c
@@ -49,6 +49,7 @@ static void (*writestatus) () = setroot;
 //opens process *cmd and stores output in *output
 void getcmd(const Block *block, char *output)
 {
+	memset(output,0,strlen(output));
 	strcpy(output, block->icon);
 	char *cmd = block->command;
 	FILE *cmdf = popen(cmd,"r");


### PR DESCRIPTION
With latest addition to allowing delimiter being more than one char, I had problem that when block width changes there are some random looking parts of delimiter left on status bar. I'm not a programmer, so this might be wrong way to fix it, but it seemed simple solution. When current block is cleared before update, weird extra delimiters disappeared.

I had blocks which showed current netspeeds, and problems were mainly around them.