### PR TITLE
Add the call to pclose() when the output from the block command is empty

### DIFF
--- a/dwmblocks.c
+++ b/dwmblocks.c
@@ -65,8 +65,11 @@ void getcmd(const Block *block, char *output)
 	int i = strlen(block->icon);
 	fgets(output+i, CMDLENGTH-i-delimLen, cmdf);
 	i = strlen(output);
-	if (i == 0)//return if block and command output are both empty
+	if (i == 0) {
+		//return if block and command output are both empty
+		pclose(cmdf);
 		return;
+	}
 	if (delim[0] != '\0') {
 		//only chop off newline if one is present at the end
 		i = output[i-1] == '\n' ? i-1 : i;


### PR DESCRIPTION
Currently, as stated in the [Reddit article](https://www.reddit.com/r/suckless/comments/jvxsr1/dwmblocks_spawning_zombie_processes_for_currently/) `dwmblocks` leaves zombie processes when the blocks command exits without outputting anything. This patch adds the call to `pclose()` before returning in the relevant if-block.

Credits to [u/GimmeYaMoney](https://www.reddit.com/user/GimmeYaMoney) for discovering this bug.