### PR TITLE
Remove blocks.def.h from Makefile outputs and blocks.h from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# Custom blocks file
-blocks.h
-
 # Prerequisites
 *.d
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PREFIX ?= /usr/local
 CC ?= cc
 LDFLAGS = -lX11
 
-output: dwmblocks.c blocks.def.h blocks.h
+output: dwmblocks.c blocks.h
 	${CC}  dwmblocks.c $(LDFLAGS) -o dwmblocks
 blocks.h:
 	cp blocks.def.h $@


### PR DESCRIPTION
`dwm` or `st` would compile fine without ` config.def.h` file, and wouldn't add `config.h` in `.gitignore`.

I don't see why `dwmblocks` should be any different with `blocks.def.h` and `blocks.h`

Basically, I'm happy for the addition of `blocks.def.h`, but I'm against the rest of what  torrinfail@7e0bc3f5801ba70fcf6d5824a74e29836b2d57b7 stands for.