### PR TITLE
BSD support in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ PREFIX  ?= /usr/local
 CC      ?= cc
 CFLAGS  = -pedantic -Wall -Wno-deprecated-declarations -Os
 LDFLAGS = -lX11
+# FreeBSD
+#LDFLAGS += -L/usr/local/lib -I/usr/local/include
 
 all: options dwmblocks
 
@@ -18,7 +20,7 @@ blocks.h:
 	cp blocks.def.h $@
 
 clean:
-	${RM} *.o *.gch dwmblocks
+	rm -rf *.o *.gch dwmblocks
 
 install: dwmblocks
 	mkdir -p ${DESTDIR}${PREFIX}/bin
@@ -26,6 +28,6 @@ install: dwmblocks
 	chmod 755 ${DESTDIR}${PREFIX}/bin/dwmblocks
 
 uninstall:
-	${RM} ${DESTDIR}${PREFIX}/bin/dwmblocks
+	rm -rf ${DESTDIR}${PREFIX}/bin/dwmblocks
 
 .PHONY: all options clean install uninstall

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,31 @@
-PREFIX ?= /usr/local
-CC ?= cc
+PREFIX  ?= /usr/local
+CC      ?= cc
+CFLAGS  = -pedantic -Wall -Wno-deprecated-declarations -Os
 LDFLAGS = -lX11
 
-output: dwmblocks.c blocks.def.h blocks.h
-	${CC}  dwmblocks.c $(LDFLAGS) -o dwmblocks
+all: options dwmblocks
+
+options:
+	@echo dwmblocks build options:
+	@echo "CFLAGS  = ${CFLAGS}"
+	@echo "LDFLAGS = ${LDFLAGS}"
+	@echo "CC      = ${CC}"
+
+dwmblocks: dwmblocks.c blocks.def.h blocks.h
+	${CC} -o dwmblocks dwmblocks.c ${CFLAGS} ${LDFLAGS}
+
 blocks.h:
 	cp blocks.def.h $@
 
-
 clean:
-	rm -f *.o *.gch dwmblocks
-install: output
-	mkdir -p $(DESTDIR)$(PREFIX)/bin
-	install -m 0755 dwmblocks $(DESTDIR)$(PREFIX)/bin/dwmblocks
+	${RM} *.o *.gch dwmblocks
+
+install: dwmblocks
+	mkdir -p ${DESTDIR}${PREFIX}/bin
+	cp -f dwmblocks ${DESTDIR}${PREFIX}/bin
+	chmod 755 ${DESTDIR}${PREFIX}/bin/dwmblocks
+
 uninstall:
-	rm -f $(DESTDIR)$(PREFIX)/bin/dwmblocks
+	${RM} ${DESTDIR}${PREFIX}/bin/dwmblocks
+
+.PHONY: all options clean install uninstall

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ blocks.h:
 	cp blocks.def.h $@
 
 clean:
-	rm -rf *.o *.gch dwmblocks
+	rm -f *.o *.gch dwmblocks
 
 install: dwmblocks
 	mkdir -p ${DESTDIR}${PREFIX}/bin
@@ -30,6 +30,6 @@ install: dwmblocks
 	chmod 755 ${DESTDIR}${PREFIX}/bin/dwmblocks
 
 uninstall:
-	rm -rf ${DESTDIR}${PREFIX}/bin/dwmblocks
+	rm -f ${DESTDIR}${PREFIX}/bin/dwmblocks
 
 .PHONY: all options clean install uninstall

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,10 @@ PREFIX  ?= /usr/local
 CC      ?= cc
 CFLAGS  = -pedantic -Wall -Wno-deprecated-declarations -Os
 LDFLAGS = -lX11
-# FreeBSD
+# FreeBSD (uncomment)
 #LDFLAGS += -L/usr/local/lib -I/usr/local/include
+# OpenBSD (uncomment)
+#LDFLAGS += -L/usr/X11R6/lib -I/usr/X11R6/include
 
 all: options dwmblocks
 

--- a/dwmblocks.c
+++ b/dwmblocks.c
@@ -6,7 +6,7 @@
 #ifndef NO_X
 #include<X11/Xlib.h>
 #endif
-#ifdef __OpenBSD__
+#if defined(__OpenBSD__) || defined(__FreeBSD__)
 #define SIGPLUS			SIGUSR1+1
 #define SIGMINUS		SIGUSR1-1
 #else
@@ -24,7 +24,7 @@ typedef struct {
 	unsigned int interval;
 	unsigned int signal;
 } Block;
-#ifndef __OpenBSD__
+#if !defined(__OpenBSD__) || !defined(__FreeBSD__)
 void dummysighandler(int num);
 #endif
 void sighandler(int num);
@@ -102,7 +102,7 @@ void getsigcmds(unsigned int signal)
 
 void setupsignals()
 {
-#ifndef __OpenBSD__
+#if !defined(__OpenBSD__) || !defined(__FreeBSD__)
 	    /* initialize all real time signals with dummy handler */
     for (int i = SIGRTMIN; i <= SIGRTMAX; i++)
         signal(i, dummysighandler);
@@ -170,7 +170,7 @@ void statusloop()
 	}
 }
 
-#ifndef __OpenBSD__
+#if !defined(__OpenBSD__) || !defined(__FreeBSD__)
 /* this signal handler should do nothing */
 void dummysighandler(int signum)
 {


### PR DESCRIPTION
Added LDFLAGS required for OpenBSD and FreeBSD respectively along with make options to better support porting.