### PR TITLE
-Wunused-variables causes compilation to fail

### DIFF
--- a/dwmblocks.c
+++ b/dwmblocks.c
@@ -53,7 +53,6 @@ static void (*writestatus) () = pstdout;
 static char statusbar[LENGTH(blocks)][CMDLENGTH] = {0};
 static char statusstr[2][STATUSLENGTH];
 static int statusContinue = 1;
-static int returnStatus = 0;
 
 //opens process *cmd and stores output in *output
 void getcmd(const Block *block, char *output)


### PR DESCRIPTION
I'm getting the following error when compiling:

~~~
dwmblocks.c:56:12: warning: ‘returnStatus’ defined but not used [-Wunused-variable]
   56 | static int returnStatus = 0;
      |            ^~~~~~~~~~~~
~~~

This removes the declaration on line 56 and compilation continues to work.