### PR TITLE
fixed disappearing block issue when signaling

### DIFF
--- a/dwmblocks.c
+++ b/dwmblocks.c
@@ -58,25 +58,26 @@ static int returnStatus = 0;
 //opens process *cmd and stores output in *output
 void getcmd(const Block *block, char *output)
 {
-	strcpy(output, block->icon);
+	//make sure status is same until output is ready
+	char tempstatus[CMDLENGTH] = {0};
+	strcpy(tempstatus, block->icon);
 	FILE *cmdf = popen(block->command, "r");
 	if (!cmdf)
 		return;
 	int i = strlen(block->icon);
-	fgets(output+i, CMDLENGTH-i-delimLen, cmdf);
-	i = strlen(output);
-	if (i == 0) {
-		//return if block and command output are both empty
-		pclose(cmdf);
-		return;
+	fgets(tempstatus+i, CMDLENGTH-i-delimLen, cmdf);
+	i = strlen(tempstatus);
+	//if block and command output are both not empty
+	if (i != 0) {
+		//only chop off newline if one is present at the end
+		i = tempstatus[i-1] == '\n' ? i-1 : i;
+		if (delim[0] != '\0') {
+			strncpy(tempstatus+i, delim, delimLen);
+		}
+		else
+			tempstatus[i++] = '\0';
 	}
-	//only chop off newline if one is present at the end
-	i = output[i-1] == '\n' ? i-1 : i;
-	if (delim[0] != '\0') {
-		strncpy(output+i, delim, delimLen); 
-	}
-	else
-		output[i++] = '\0';
+	strcpy(output, tempstatus);
 	pclose(cmdf);
 }
 


### PR DESCRIPTION
I was experiencing issue when signaling dwmblocks. I think it happens because block outputs may not be ready when getting status of blocks. Problem can be solved with this patch.

# Demonstration
## Current behaviour
https://user-images.githubusercontent.com/55701513/221313561-ba45e1e2-5feb-4cd2-ba9b-33d7bd8fd859.mp4

## After patch
https://user-images.githubusercontent.com/55701513/221313613-337b6f2e-ab5f-44e4-a245-1801da3cb71d.mp4

