### PR TITLE
Spelling

### DIFF
--- a/blocks.def.h
+++ b/blocks.def.h
@@ -6,6 +6,6 @@ static const Block blocks[] = {
 	{"", "date '+%b %d (%a) %I:%M%p'",					5,		0},
 };
 
-//sets delimeter between status commands. NULL character ('\0') means no delimeter.
+//sets delimiter between status commands. NULL character ('\0') means no delimiter.
 static char delim[] = " | ";
 static unsigned int delimLen = 5;


### PR DESCRIPTION
"delimeter" $\rightarrow$ "delimiter"