### PR TITLE
fix: added int parameter to termhandler() function

### DIFF
--- a/dwmblocks.c
+++ b/dwmblocks.c
@@ -34,7 +34,7 @@ void setupsignals();
 void sighandler(int signum);
 int getstatus(char *str, char *last);
 void statusloop();
-void termhandler();
+void termhandler(int sig);
 void pstdout();
 #ifndef NO_X
 void setroot();
@@ -185,7 +185,7 @@ void sighandler(int signum)
 	writestatus();
 }
 
-void termhandler()
+void termhandler(int sig)
 {
 	statusContinue = 0;
 }


### PR DESCRIPTION
termhandler is defined without any parameters, added int parameter to match expected signal handler signature

this fixes the compiler error: `dwmblocks.c:207:25: error: passing argument 2 of 'signal' from incompatible pointer type [-Wincompatible-pointer-types]`
