### PR TITLE
Lazily check for update and cache strlen

### DIFF
--- a/dwmblocks.c
+++ b/dwmblocks.c
@@ -60,22 +60,9 @@ static int returnStatus = 0;
 //return ptr to nul terminator in dst
 char *xstpcpyLen(char *dst, const char *src, size_t n)
 {
-	dst = memcpy(dst, src, n) + n;
-	*dst = '\0';
-	return dst;
-}
-
-//return ptr to nul terminator in dst
-char *xstpcpy(char *dst, const char *src)
-{
-#if HAVE_STPCPY
-	return stpcpy(dst, src);
-#else
-	const size_t n = strlen(src);
 	dst = (char *)memcpy(dst, src, n) + n;
 	*dst = '\0';
 	return dst;
-#endif
 }
 
 //opens process *cmd and stores output in *output
@@ -84,7 +71,7 @@ char *getcmd(const Block *block, char *output, unsigned int outputOldLen)
 	//make sure status is same until output is ready
 	char tempstatus[CMDLENGTH];
 	char *endp = tempstatus;
-	endp = xstpcpy(endp, block->icon);
+	endp = xstpcpyLen(endp, block->icon, strlen(block->icon));
 	FILE *cmdf = popen(block->command, "r");
 	if (!cmdf)
 		return output + outputOldLen;

--- a/dwmblocks.c
+++ b/dwmblocks.c
@@ -66,7 +66,7 @@ char *xstpcpyLen(char *dst, const char *src, size_t n)
 	return dst;
 }
 
-//opens process *cmd and stores output in *output
+//opens process *cmd and stores output in *output, returns ptr to nul terminator in output
 char *getcmd(const Block *block, char *output, unsigned int outputOldLen)
 {
 	//make sure status is same until output is ready

--- a/dwmblocks.c
+++ b/dwmblocks.c
@@ -34,7 +34,7 @@ void setupsignals();
 void sighandler(int signum);
 int getstatus(char *str);
 void statusloop();
-void termhandler();
+void termhandler(int);
 void pstdout();
 #ifndef NO_X
 void setroot();
@@ -89,7 +89,7 @@ char *getcmd(const Block *block, char *output, unsigned int outputOldLen)
 		xstpcpyLen(endp, delim, MIN(delimLen, CMDLENGTH-(endp-tempstatus)));
 	}
 	//mark if there is a change and copy
-	if (outputOldLen != endp - tempstatus || memcmp(tempstatus, output, outputOldLen)) {
+	if (outputOldLen != endp-tempstatus || memcmp(tempstatus, output, outputOldLen)) {
 		statusChanged = 1;
 		endp = xstpcpyLen(output, tempstatus, endp-tempstatus);
 		return endp;
@@ -206,7 +206,7 @@ void sighandler(int signum)
 	writestatus();
 }
 
-void termhandler()
+void termhandler(int unused)
 {
 	statusContinue = 0;
 }

--- a/dwmblocks.c
+++ b/dwmblocks.c
@@ -76,7 +76,7 @@ char *getcmd(const Block *block, char *output, unsigned int outputOldLen)
 	FILE *cmdf = popen(block->command, "r");
 	if (!cmdf)
 		return output + outputOldLen;
-	unsigned int readLen = fread(endp, 1, CMDLENGTH-(endp-tempstatus)-delimLen, cmdf);
+	unsigned int readLen = fread(endp, 1, CMDLENGTH-(endp-tempstatus)-delimLen+1, cmdf);
 	pclose(cmdf);
 	tempstatus[readLen] = '\0';
 	//if block and command output are both not empty
@@ -87,7 +87,7 @@ char *getcmd(const Block *block, char *output, unsigned int outputOldLen)
 			nl[0] = '\0';
 			endp = nl;
 		}
-		endp = xstpcpyLen(endp, delim, MIN(delimLen, CMDLENGTH-(endp-tempstatus)));
+		endp = xstpcpyLen(endp, delim, MIN(delimLen+1, CMDLENGTH-(endp-tempstatus)));
 	}
 	//mark if there is a change and copy
 	if (outputOldLen != endp-tempstatus || memcmp(tempstatus, output, outputOldLen)) {
@@ -116,9 +116,10 @@ void getsigcmds(unsigned int signal)
 	const Block *current;
 	for (unsigned int i = 0; i < LENGTH(blocks); i++) {
 		current = blocks + i;
-		if (current->signal == signal)
+		if (current->signal == signal) {
 			//cache strlen
 			statusbarlen[i] = getcmd(current,statusbar[i],statusbarlen[i]) - statusbar[i];
+		}
 	}
 }
 

--- a/dwmblocks.c
+++ b/dwmblocks.c
@@ -66,7 +66,7 @@ char *xstpcpyLen(char *dst, const char *src, size_t n)
 	return dst;
 }
 
-//opens process *cmd and stores output in *output, returns ptr to nul terminator in output
+//opens process *cmd and stores output in *output
 char *getcmd(const Block *block, char *output, unsigned int outputOldLen)
 {
 	//make sure status is same until output is ready
@@ -76,7 +76,7 @@ char *getcmd(const Block *block, char *output, unsigned int outputOldLen)
 	FILE *cmdf = popen(block->command, "r");
 	if (!cmdf)
 		return output + outputOldLen;
-	unsigned int readLen = fread(endp, 1, CMDLENGTH-(endp-tempstatus)-delimLen+1, cmdf);
+	unsigned int readLen = fread(endp, 1, CMDLENGTH-(endp-tempstatus)-delimLen-1, cmdf);
 	pclose(cmdf);
 	tempstatus[readLen] = '\0';
 	//if block and command output are both not empty
@@ -87,7 +87,7 @@ char *getcmd(const Block *block, char *output, unsigned int outputOldLen)
 			nl[0] = '\0';
 			endp = nl;
 		}
-		endp = xstpcpyLen(endp, delim, MIN(delimLen+1, CMDLENGTH-(endp-tempstatus)));
+		endp = xstpcpyLen(endp, delim, delimLen);
 	}
 	//mark if there is a change and copy
 	if (outputOldLen != endp-tempstatus || memcmp(tempstatus, output, outputOldLen)) {

--- a/dwmblocks.c
+++ b/dwmblocks.c
@@ -156,6 +156,7 @@ void setroot()
 	getstatus(statusstr);
 	XStoreName(dpy, root, statusstr);
 	XFlush(dpy);
+	statusChanged = 0;
 }
 
 int setupX()
@@ -176,6 +177,7 @@ void pstdout()
 	getstatus(statusstr);
 	printf("%s\n",statusstr);
 	fflush(stdout);
+	statusChanged = 0;
 }
 
 
@@ -188,7 +190,6 @@ void statusloop()
 		getcmds(i++);
 		if (statusChanged)//Only write out if text has changed.
 			writestatus();
-		statusChanged = 0;
 		if (!statusContinue)
 			break;
 		sleep(1.0);
@@ -207,7 +208,6 @@ void sighandler(int signum)
 {
 	getsigcmds(signum-SIGPLUS);
 	writestatus();
-	statusChanged = 0;
 }
 
 void termhandler(int unused)

--- a/dwmblocks.c
+++ b/dwmblocks.c
@@ -3,6 +3,7 @@
 #include<string.h>
 #include<unistd.h>
 #include<signal.h>
+#include<assert.h>
 #ifndef NO_X
 #include<X11/Xlib.h>
 #endif
@@ -86,7 +87,7 @@ char *getcmd(const Block *block, char *output, unsigned int outputOldLen)
 			nl[0] = '\0';
 			endp = nl;
 		}
-		xstpcpyLen(endp, delim, MIN(delimLen, CMDLENGTH-(endp-tempstatus)));
+		endp = xstpcpyLen(endp, delim, MIN(delimLen, CMDLENGTH-(endp-tempstatus)));
 	}
 	//mark if there is a change and copy
 	if (outputOldLen != endp-tempstatus || memcmp(tempstatus, output, outputOldLen)) {
@@ -103,9 +104,10 @@ void getcmds(int time)
 	const Block* current;
 	for (unsigned int i = 0; i < LENGTH(blocks); i++) {
 		current = blocks + i;
-		if ((current->interval != 0 && time % current->interval == 0) || time == -1)
+		if ((current->interval != 0 && time % current->interval == 0) || time == -1) {
 			//cache strlen
 			statusbarlen[i] = getcmd(current,statusbar[i],statusbarlen[i]) - statusbar[i];
+		}
 	}
 }
 
@@ -139,7 +141,7 @@ int getstatus(char *str)
 {
 	char *p = str;
 	for (unsigned int i = 0; i < LENGTH(blocks); i++)
-		p = xstpcpyLen(str, p, statusbarlen[i]);
+		p = xstpcpyLen(p, statusbar[i], statusbarlen[i]);
 	if (p != str) {
 		p -= delimLen;
 		*p = '\0';

--- a/dwmblocks.c
+++ b/dwmblocks.c
@@ -3,7 +3,6 @@
 #include<string.h>
 #include<unistd.h>
 #include<signal.h>
-#include<assert.h>
 #ifndef NO_X
 #include<X11/Xlib.h>
 #endif

--- a/dwmblocks.c
+++ b/dwmblocks.c
@@ -207,6 +207,7 @@ void sighandler(int signum)
 {
 	getsigcmds(signum-SIGPLUS);
 	writestatus();
+	statusChanged = 0;
 }
 
 void termhandler(int unused)


### PR DESCRIPTION
Instead of comparing the whole statusstr to the old statusstr (in getstatus), only compare the result of each shell script that is currently called to the old result (in getcmd), and before comparing, check whether the length of the new string is different to the old string, the old length being cached, in which case we can avoid the comparison.

delimLen is made equal to strlen(delim) to avoid confusion.