### PR TITLE
dummysighandler: warn unknown signal errors

### DIFF
--- a/dwmblocks.c
+++ b/dwmblocks.c
@@ -175,6 +175,7 @@ void statusloop()
 /* this signal handler should do nothing */
 void dummysighandler(int signum)
 {
+    fprintf(stderr, "dwmblocks: receiving unknown signal: %d\n", signum);
     return;
 }
 #endif


### PR DESCRIPTION
#8 fixes #5 by silently ignoring unknown signals, but it would be useful to warn the user that the signal that is received is invalid.